### PR TITLE
Switch to Kraft mode

### DIFF
--- a/.kluctl.yaml
+++ b/.kluctl.yaml
@@ -42,8 +42,8 @@ args:
   ### Feature flags for included manifests
   - name: with_backups
     default: false
-  - name: with_kafka_kraft # strimzi doesn't support topicOperator with KRAFT yet
-    default: false
+  - name: with_kafka_kraft # strimzi doesn't support topicOperator with KRAFT yet, but we auto create topics on use
+    default: true
   - name: with_kafka_ui
     default: true
   - name: with_local_path_as_default_storageclass


### PR DESCRIPTION
We aren't using kafka long term persistence or forcing kafka topic states, so use kraft to simplify deployments.