### PR TITLE
Add ers-protobuf-dbwriter service

### DIFF
--- a/dune_daq_services/ers/deployment.yml
+++ b/dune_daq_services/ers/deployment.yml
@@ -11,6 +11,7 @@ deployments:
     message: Let services all catch up
 
   - path: ers-dbwriter
+  - path: ers-protobuf-dbwriter
 
 vars:
   - file: variables/ers.yaml

--- a/dune_daq_services/ers/ers-dbwriter/kustomization.yml
+++ b/dune_daq_services/ers/ers-dbwriter/kustomization.yml
@@ -19,3 +19,10 @@ patches:
       - op: replace
         path: /spec/template/spec/containers/0/env/1/value
         value: {{ dunedaq.kafka.bootstrap_brokers[0] }}
+  - target:
+      kind: Namespace
+    patch: |-
+      $patch: delete
+      kind: Kustomization
+      metadata:
+        name: DOES NOT MATTER

--- a/dune_daq_services/ers/ers-protobuf-dbwriter/ers-dbwriter-deployment.yaml
+++ b/dune_daq_services/ers/ers-protobuf-dbwriter/ers-dbwriter-deployment.yaml
@@ -1,0 +1,1 @@
+../../../.submodules/dune-daq-microservices/ers-protobuf-dbwriter/ers-dbwriter-deployment.yaml

--- a/dune_daq_services/ers/ers-protobuf-dbwriter/kustomization.yml
+++ b/dune_daq_services/ers/ers-protobuf-dbwriter/kustomization.yml
@@ -19,3 +19,10 @@ patches:
       - op: replace
         path: /spec/template/spec/containers/0/env/1/value
         value: {{ dunedaq.kafka.bootstrap_brokers[0] }}
+  - target:
+      kind: Namespace
+    patch: |-
+      $patch: delete
+      kind: Kustomization
+      metadata:
+        name: DOES NOT MATTER

--- a/dune_daq_services/ers/ers-protobuf-dbwriter/kustomization.yml
+++ b/dune_daq_services/ers/ers-protobuf-dbwriter/kustomization.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: {{ DUNE_ers.namespace }}
+
+resources:
+  - ers-dbwriter-deployment.yaml
+
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: {{ dunedaq.unified_microservices.image }}:{{ dunedaq.unified_microservices.tag }}
+      - op: replace
+        path: /spec/template/spec/containers/0/env/1/value
+        value: {{ dunedaq.kafka.bootstrap_brokers[0] }}

--- a/dune_daq_services/variables/dunedaq.yaml
+++ b/dune_daq_services/variables/dunedaq.yaml
@@ -15,4 +15,4 @@ dunedaq:
     replicas: 1
   unified_microservices:
     image: ghcr.io/dune-daq/microservices
-    tag: fa6c
+    tag: "9685"  # note this must be a string!


### PR DESCRIPTION
I think this captures Marco's changes from https://github.com/DUNE-DAQ/daq-kube/pull/9 while leaving the non-protobuf bits out for consumption in a separate PR.

Needed a real working tree to test them at NP04, now that they are tested we can slice out the bits logically.

Marco, I've got a single ERS target that deploys both.  I noticed you made a separate one for just the protobuf bits.  I can go either way on that.  On the one hand, strong isolation makes testing easier, on the other, getting all the ERS bits under one command helps folks "get and ERS and not worry about which one their code uses."  Thoughts?