### PR TITLE
bump the run registry image

### DIFF
--- a/dune_daq_services/runservices/runregistry-rest/runregistry.yml
+++ b/dune_daq_services/runservices/runregistry-rest/runregistry.yml
@@ -27,7 +27,7 @@ spec:
              - key: {{ kubernetes_label.worker }}
                operator: Exists
       containers:
-      - image: ghcr.io/dune-daq/pocket-runregistry-rest:v0.0.9
+      - image: ghcr.io/dune-daq/pocket-runregistry-rest:v0.0.10
         name: runregistry-rest
         env:
         - name: MICROSERVICE


### PR DESCRIPTION
... as the previous attempt used an image which contained an outdated microservice repo.

For the next one here, you need to `docker system prune -a`, otherwise `docker` potentially uses a cached microservice repo which could be old.