### PR TITLE
Increase kafka limits for iceberg

### DIFF
--- a/dune_daq_services/kafka/kafka-server/kafka.yml
+++ b/dune_daq_services/kafka/kafka-server/kafka.yml
@@ -129,7 +129,11 @@ spec:
       auto.create.topics.enable: true
       log.cleanup.policy: "delete" # Cannot use 'compact' due to empty key in our data format
       log.retention.bytes: 6442450944 # no default upper size limit, set to 6Gi
-      max.message.bytes: 1048576 # if you change this you need to review the kafka docs
+
+      message.max.bytes: 402653184 # if you change this you need to review the kafka docs
+      replica.fetch.max.bytes: 402653184 # if you change this you need to review the kafka docs
+      replica.fetch.response.max.bytes: 402653184 # if you change this you need to review the kafka docs
+      max.partition.fetch.bytes: 402653184 # if you change this you need to review the kafka docs
 {% if dunedaq.kafka.replicas < 3 %}
       # replication only makes sense if there are 3 or more brokers
       transaction.state.log.min.isr: 1


### PR DESCRIPTION
Attempt to fix:
```
2024-06-10 08:08:44,676 WARN [SocketServer listenerType=BROKER, nodeId=0] Unexpected error from /10.89.0.3 (channelId=10.244.1.44:9094-10.89.0.3:51686-2561); closing connection (org.apache.kafka.common.network.Selector) [data-plane-kafka-network-thread-0-ListenerName(EXTERNAL-9094)-PLAINTEXT-11]
org.apache.kafka.common.network.InvalidReceiveException: Invalid receive (size = 369295618 larger than 104857600)
	at org.apache.kafka.common.network.NetworkReceive.readFrom(NetworkReceive.java:94)
	at org.apache.kafka.common.network.KafkaChannel.receive(KafkaChannel.java:452)
	at org.apache.kafka.common.network.KafkaChannel.read(KafkaChannel.java:402)
	at org.apache.kafka.common.network.Selector.attemptRead(Selector.java:674)
	at org.apache.kafka.common.network.Selector.pollSelectionKeys(Selector.java:576)
	at org.apache.kafka.common.network.Selector.poll(Selector.java:481)
	at kafka.network.Processor.poll(SocketServer.scala:1107)
	at kafka.network.Processor.run(SocketServer.scala:1011)
	at java.base/java.lang.Thread.run(Thread.java:840)
```